### PR TITLE
Improve acceptance tests in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,7 @@ jobs:
           command: CGO_ENABLED=0 make test-acceptance
       - run:
           name: "Wait for deletion"
+          when: always
           command: |
             echo "Waiting for cluster deletion"
             while [[ -n "$(kubectl get clusters --all-namespaces -o name)" ]]; do


### PR DESCRIPTION
This does a few things:
1. Make running acceptance tests less likely to flake. It achieves this by creating only two clusters - one for testing record creation and one for record removal. This in theory should reduce the amount of DNS lookups needed, since only the first Eventually will be polling for a long time. The other Eventuallies should pass on the first or second try.
1. Always wait for cleanup in CI. There is a cleanup job, but it doesn't wait on failures, which means that a lot of records leak.
1. Use the kind cluster explicitly when running the deploy target. This wasn't the case before and relied on `kind create cluster` to target the cluster before running `helm install`. This was very annoying (and dangerous) when running locally