### PR TITLE
catch-deleted-zone-error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Skip deletion when the zone is deleted.
+
 ## [0.5.0] - 2022-06-22
 
 - Add DNS record for bastion nodes.

--- a/pkg/registrar/bastion.go
+++ b/pkg/registrar/bastion.go
@@ -77,7 +77,10 @@ func (r *Bastion) Unregister(ctx context.Context, cluster *capg.GCPCluster) erro
 		Context(ctx).
 		Do()
 
-	if err != nil {
+	if hasHttpCode(err, http.StatusNotFound) {
+		logger.Info("Skipping. Zone already unregistered")
+		return nil
+	} else if err != nil {
 		return microerror.Mask(err)
 	}
 


### PR DESCRIPTION
```
2022-06-22T12:13:05Z	ERROR	Reconciler error	{"controller": "gcpcluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "GCPCluster", "gCPCluster": {"name":"jose555","namespace":"org-jose"}, "namespace": "org-jose", "name": "jose555", "reconcileID": "8cee1478-e768-4407-9bf5-a7e4f1a58343", "error": "googleapi: Error 404: The 'parameters.managedZone' resource named 'jose555' does not exist., notFound"}
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.12.1/pkg/internal/controller/controller.go:273
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.12.1/pkg/internal/controller/controller.go:234
```
