### PR TITLE
dont-error-on-no-bastion

### DIFF
--- a/pkg/k8sclient/bastion_test.go
+++ b/pkg/k8sclient/bastion_test.go
@@ -149,7 +149,7 @@ var _ = Describe("MachineList", func() {
 					},
 				}
 				ipList, err := bastions.GetBastionIPList(ctx, otherCluster)
-				Expect(err).To(MatchError(ContainSubstring(`bastion IP is not yet available`)))
+				Expect(err).To(BeNil())
 				Expect(ipList).To(BeNil())
 			})
 		})

--- a/pkg/k8sclient/bastions.go
+++ b/pkg/k8sclient/bastions.go
@@ -48,10 +48,6 @@ func (b *Bastions) GetBastionIPList(ctx context.Context, cluster *capg.GCPCluste
 		}
 	}
 
-	if len(bastionPublicIPList) == 0 {
-		return nil, errors.New("bastion IP is not yet available")
-	}
-
 	return bastionPublicIPList, nil
 }
 

--- a/pkg/registrar/bastion.go
+++ b/pkg/registrar/bastion.go
@@ -42,33 +42,33 @@ func (r *Bastion) Register(ctx context.Context, cluster *capg.GCPCluster) error 
 
 	if len(bastionIPList) == 0 {
 		logger.Info("No bastion resource found, skipping DNS record creation")
-	} else {
-		for i, bastionIP := range bastionIPList {
-			bastionDomain := fmt.Sprintf("%s.%s.%s.", EndpointBastion(i+1), cluster.Name, r.baseDomain)
-			logger := logger.WithValues("record", bastionDomain)
-			logger.Info("Registering record")
+		return nil
+	}
+	for i, bastionIP := range bastionIPList {
+		bastionDomain := fmt.Sprintf("%s.%s.%s.", EndpointBastion(i+1), cluster.Name, r.baseDomain)
+		logger := logger.WithValues("record", bastionDomain)
+		logger.Info("Registering record")
 
-			record := &clouddns.ResourceRecordSet{
-				Name: bastionDomain,
-				Rrdatas: []string{
-					bastionIP,
-				},
-				Type: RecordA,
-			}
-			_, err = r.dnsService.ResourceRecordSets.Create(cluster.Spec.Project, cluster.Name, record).
-				Context(ctx).
-				Do()
+		record := &clouddns.ResourceRecordSet{
+			Name: bastionDomain,
+			Rrdatas: []string{
+				bastionIP,
+			},
+			Type: RecordA,
+		}
+		_, err = r.dnsService.ResourceRecordSets.Create(cluster.Spec.Project, cluster.Name, record).
+			Context(ctx).
+			Do()
 
-			if hasHttpCode(err, http.StatusConflict) {
-				err = r.updateBastionRecordIfNotUptoDate(ctx, cluster, record, logger)
-				if err != nil {
-					return microerror.Mask(err)
-				}
-			} else if err != nil {
+		if hasHttpCode(err, http.StatusConflict) {
+			err = r.updateBastionRecordIfNotUptoDate(ctx, cluster, record, logger)
+			if err != nil {
 				return microerror.Mask(err)
 			}
-			logger.Info("Done Registering record", "ip", bastionIP)
+		} else if err != nil {
+			return microerror.Mask(err)
 		}
+		logger.Info("Done Registering record", "ip", bastionIP)
 	}
 
 	return nil


### PR DESCRIPTION
don't error when there are no bastions yet, just log info message and skip record creation

when the cluster is created the CAPI first init control plane node and only after that it will create other machines so there is a time frame where the cluster exists and there is no bastion and this causes an error that is not a real error