### PR TITLE
Only apply PSP is object is registered in the k8s API

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -3,3 +3,8 @@
 CVE-2019-10743 until=2021-10-17
 CVE-2022-29153
 CVE-2022-24687
+
+# pkg:golang/github.com/hashicorp/consul/api@v1.10.1
+# Hashicorp consul /api and /sdk are no longer intended for public use and don't have newer tags.
+# Waiting for direct dependencies to move away from them.
+CVE-2021-41803

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `PodSecurityPolicy` are removed on newer k8s versions, so only apply it if object is registered in the k8s API.
+
 ## [0.5.2] - 2022-07-01
 
 ### Removed

--- a/helm/dns-operator-gcp/templates/psp.yaml
+++ b/helm/dns-operator-gcp/templates/psp.yaml
@@ -1,3 +1,4 @@
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -26,3 +27,4 @@ spec:
   hostNetwork: false
   hostIPC: false
   hostPID: false
+{{- end }}

--- a/helm/dns-operator-gcp/templates/rbac.yaml
+++ b/helm/dns-operator-gcp/templates/rbac.yaml
@@ -57,6 +57,7 @@ roleRef:
   name: {{ include "resource.default.name"  . }}
   apiGroup: rbac.authorization.k8s.io
 ---
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -65,7 +66,7 @@ metadata:
   {{- include "labels.common" . | nindent 4 }}
 rules:
   - apiGroups:
-      - extensions
+      - policy
     resources:
       - podsecuritypolicies
     verbs:
@@ -87,3 +88,4 @@ roleRef:
   kind: ClusterRole
   name: {{ include "resource.psp.name" . }}
   apiGroup: rbac.authorization.k8s.io
+{{- end }}


### PR DESCRIPTION
`PodSecurityPolicy` are removed on newer k8s versions, so only apply it if object is registered in the k8s API.